### PR TITLE
Service Bug Fix

### DIFF
--- a/carbon_server/carbon_server.py
+++ b/carbon_server/carbon_server.py
@@ -55,6 +55,12 @@ class ProjectDAO(object):
         else:
             self.cp_db=client.create_database(db_name)
             self.import_data()
+        
+        # There's something strange going on here. If I don't call list (or call say the get method)
+        # then the cp_db object is not populated with any results. This makes the first 
+        # getnitems call to the services fail
+        all_items = self.list()
+        del all_items
             
     def import_data(self):
         """

--- a/carbon_server_cloud/carbon_server.py
+++ b/carbon_server_cloud/carbon_server.py
@@ -98,6 +98,12 @@ class ProjectDAO(object):
         else:
             self.cp_db=client.create_database(db_name)
             self.import_data()
+        
+        # There's something strange going on here. If I don't call list (or call say the get method)
+        # then the cp_db object is not populated with any results. This makes the first 
+        # getnitems call to the services fail
+        all_items = self.list()
+        del all_items
             
     def import_data(self):
         """


### PR DESCRIPTION
Found a bug where the first service call was failing b/c the cloudant db object
used did not contain any records until *after* the first time it was called.
After initializing, now call the list() function to populate records